### PR TITLE
🔧 Add test pypi publishing, more cleanups

### DIFF
--- a/.github/workflows/test-release.yaml
+++ b/.github/workflows/test-release.yaml
@@ -1,0 +1,33 @@
+---
+name: Test Upload Python Package to Test PyPI
+
+"on":
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: testing
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "pyproject.toml"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          activate-environment: "true"
+      - name: Install dependencies
+        run: |
+          uv sync --all-extras --dev
+      - name: Build
+        run: python -m build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,6 @@
 ---
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  - repo: builtin
     hooks:
       - id: check-added-large-files
       - id: check-merge-conflict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ keywords = [
     "prometheus",
     "homekit",
 ]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",
 ]
@@ -28,7 +28,7 @@ dependencies = ["prometheus_client", "environs"]
 dynamic = ["version"]
 
 [project.urls]
-repository = "https://github.com/jerr0328/co2-mini"
+repository = "https://github.com/jerr0328/co2mini"
 
 [project.optional-dependencies]
 homekit = ["hap-python"]
@@ -65,9 +65,6 @@ extend-select = [
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings
 ]
-
-[tool.isort]
-profile = "black"
 
 [tool.setuptools_scm]
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
- Add workflow to publish to test pypi on main branch builds
- Use builtin repo for prek's pre-commit hooks (breaks pre-commit usage, use prek instead)
- Use SPDX license instead of classifier
- Remove setup.py